### PR TITLE
Add pylibjpeg plugins rle and openjpeg

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ requirements:
     - setuptools
   run:
     - nibabel >=5.3.1
-    - pydicom >=0.9.7
     - pint
+    - pydicom >=0.9.7
     - python
     - pylibjpeg-libjpeg >=2.3.0
     - pylibjpeg-openjpeg >=2.4.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Feedstocks for these two plugins were recently created. 
- https://github.com/conda-forge/pylibjpeg-openjpeg-feedstock
- https://github.com/conda-forge/pylibjpeg-rle-feedstock

Adding them to this recipe brings the dcmstack feedstock into alignment with the pypi version, [which grabs all available plugins](https://github.com/moloney/dcmstack/blob/68575996c8956152865e3598b15f621d7c803a96/src/dcmstack/info.py#L28).